### PR TITLE
feat: add application tracking pipeline

### DIFF
--- a/backend/app/Enums/ApplicationStatus.php
+++ b/backend/app/Enums/ApplicationStatus.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Enums;
+
+enum ApplicationStatus: string
+{
+    case Applied = 'applied';
+    case OnlineAssessment = 'online_assessment';
+    case Interview = 'interview';
+    case Passed = 'passed';
+    case Rejected = 'rejected';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Applied => 'Applied',
+            self::OnlineAssessment => 'Online Assessment',
+            self::Interview => 'Interview',
+            self::Passed => 'Passed',
+            self::Rejected => 'Rejected',
+        };
+    }
+
+    public static function values(): array
+    {
+        return array_map(static fn (self $status) => $status->value, self::cases());
+    }
+}

--- a/backend/app/Http/Controllers/ApplicationController.php
+++ b/backend/app/Http/Controllers/ApplicationController.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Enums\ApplicationStatus;
+use App\Http\Resources\ApplicationResource;
+use App\Models\Application;
+use App\Support\ApplicationReportBuilder;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Illuminate\Validation\Rule;
+
+class ApplicationController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $user = $request->user();
+
+        abort_unless($user, 401);
+
+        $applications = $user->applications()
+            ->latest('last_activity_at')
+            ->latest()
+            ->get();
+
+        $report = ApplicationReportBuilder::fromCollection($applications);
+
+        return ApplicationResource::collection($applications)
+            ->additional([
+                'meta' => [
+                    'pipeline' => $report->pipeline(),
+                    'activity' => $report->timeline(),
+                    'counts' => $report->counts(),
+                ],
+            ])
+            ->response();
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $user = $request->user();
+
+        abort_unless($user, 401);
+
+        $validated = $this->validatePayload($request);
+
+        $application = $user->applications()->create([
+            'company' => $validated['company'],
+            'job_title' => $validated['job_title'],
+            'location' => $validated['location'] ?? null,
+            'mode' => $validated['mode'] ?? null,
+            'source' => $validated['source'] ?? null,
+            'status' => ApplicationStatus::from($validated['status'] ?? ApplicationStatus::Applied->value),
+            'job_url' => $validated['job_url'] ?? null,
+            'applied_at' => isset($validated['applied_at']) ? Carbon::parse($validated['applied_at']) : null,
+            'last_activity_at' => isset($validated['last_activity_at'])
+                ? Carbon::parse($validated['last_activity_at'])
+                : now(),
+            'notes' => $validated['notes'] ?? null,
+        ]);
+
+        return (new ApplicationResource($application))
+            ->response()
+            ->setStatusCode(201);
+    }
+
+    public function update(Request $request, Application $application): JsonResponse
+    {
+        $user = $request->user();
+
+        abort_unless($user && $application->user_id === $user->getKey(), 403);
+
+        $validated = $this->validatePayload($request, isUpdate: true);
+
+        if (array_key_exists('company', $validated)) {
+            $application->company = $validated['company'];
+        }
+
+        if (array_key_exists('job_title', $validated)) {
+            $application->job_title = $validated['job_title'];
+        }
+
+        foreach (['location', 'mode', 'source', 'job_url', 'notes'] as $attribute) {
+            if (array_key_exists($attribute, $validated)) {
+                $application->{$attribute} = $validated[$attribute];
+            }
+        }
+
+        if (array_key_exists('applied_at', $validated)) {
+            $application->applied_at = $validated['applied_at']
+                ? Carbon::parse($validated['applied_at'])
+                : null;
+        }
+
+        if (array_key_exists('last_activity_at', $validated)) {
+            $application->last_activity_at = $validated['last_activity_at']
+                ? Carbon::parse($validated['last_activity_at'])
+                : null;
+        }
+
+        if (array_key_exists('status', $validated)) {
+            $newStatus = ApplicationStatus::from($validated['status']);
+
+            if ($application->status !== $newStatus) {
+                $application->last_activity_at = $validated['last_activity_at']
+                    ? Carbon::parse($validated['last_activity_at'])
+                    : now();
+            }
+
+            $application->status = $newStatus;
+        }
+
+        $application->save();
+
+        return (new ApplicationResource($application))->response();
+    }
+
+    protected function validatePayload(Request $request, bool $isUpdate = false): array
+    {
+        $rules = [
+            'company' => [$isUpdate ? 'sometimes' : 'required', 'string', 'max:255'],
+            'job_title' => [$isUpdate ? 'sometimes' : 'required', 'string', 'max:255'],
+            'location' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'mode' => ['sometimes', 'nullable', Rule::in(['remote', 'hybrid', 'onsite'])],
+            'source' => ['sometimes', 'nullable', Rule::in(['scraped', 'manual'])],
+            'status' => ['sometimes', 'nullable', Rule::in(ApplicationStatus::values())],
+            'job_url' => ['sometimes', 'nullable', 'url', 'max:2048'],
+            'applied_at' => ['sometimes', 'nullable', 'date'],
+            'last_activity_at' => ['sometimes', 'nullable', 'date'],
+            'notes' => ['sometimes', 'nullable', 'string'],
+        ];
+
+        return $request->validate($rules);
+    }
+}

--- a/backend/app/Http/Resources/ApplicationResource.php
+++ b/backend/app/Http/Resources/ApplicationResource.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin \App\Models\Application */
+class ApplicationResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => (string) $this->getKey(),
+            'title' => $this->job_title,
+            'company' => $this->company,
+            'location' => $this->location,
+            'mode' => $this->mode ?? 'remote',
+            'status' => $this->status->value,
+            'statusLabel' => $this->status->label(),
+            'source' => $this->source ?? 'manual',
+            'postedAt' => optional($this->applied_at)->toDateString(),
+            'lastActivity' => optional($this->last_activity_at ?? $this->updated_at)->toIso8601String(),
+            'notes' => $this->notes,
+            'url' => $this->job_url,
+        ];
+    }
+}

--- a/backend/app/Models/Application.php
+++ b/backend/app/Models/Application.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\ApplicationStatus;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Application extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'company',
+        'job_title',
+        'location',
+        'mode',
+        'source',
+        'status',
+        'job_url',
+        'applied_at',
+        'last_activity_at',
+        'notes',
+    ];
+
+    protected $casts = [
+        'applied_at' => 'date',
+        'last_activity_at' => 'datetime',
+        'status' => ApplicationStatus::class,
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
@@ -47,5 +48,10 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    public function applications(): HasMany
+    {
+        return $this->hasMany(Application::class);
     }
 }

--- a/backend/app/Support/ApplicationReportBuilder.php
+++ b/backend/app/Support/ApplicationReportBuilder.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace App\Support;
+
+use App\Enums\ApplicationStatus;
+use App\Models\Application;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+
+class ApplicationReportBuilder
+{
+    /**
+     * @param Collection<int, Application> $applications
+     */
+    public function __construct(
+        protected Collection $applications
+    ) {
+    }
+
+    public static function fromCollection(Collection $applications): self
+    {
+        return new self($applications);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function pipeline(): array
+    {
+        return collect(ApplicationStatus::cases())
+            ->map(function (ApplicationStatus $status) {
+                $items = $this->applications->filter(
+                    fn (Application $application) => $application->status === $status
+                );
+
+                return [
+                    'stage' => $status->value,
+                    'label' => $status->label(),
+                    'summary' => $this->summaryFor($status),
+                    'count' => $items->count(),
+                    'jobs' => $items
+                        ->sortByDesc(fn (Application $app) => $app->last_activity_at ?? $app->updated_at)
+                        ->take(4)
+                        ->map(function (Application $application) use ($status) {
+                            $appliedAt = $application->applied_at instanceof Carbon
+                                ? $application->applied_at
+                                : ($application->applied_at ? Carbon::parse($application->applied_at) : $application->created_at);
+
+                            return [
+                                'id' => (string) $application->getKey(),
+                                'role' => $application->job_title,
+                                'company' => $application->company,
+                                'status' => $status->label(),
+                                'applied_at' => optional($appliedAt)->diffForHumans() ?? 'just now',
+                            ];
+                        })
+                        ->values()
+                        ->all(),
+                ];
+            })
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function activity(int $limit = 5): array
+    {
+        return $this->applications
+            ->sortByDesc(fn (Application $application) => $application->last_activity_at ?? $application->updated_at)
+            ->take($limit)
+            ->map(function (Application $application) {
+                $timestamp = $application->last_activity_at ?? $application->updated_at;
+
+                return [
+                    'title' => $application->job_title,
+                    'description' => $application->notes
+                        ? $application->notes
+                        : sprintf(
+                            '%s status updated to %s',
+                            $application->company,
+                            $application->status->label()
+                        ),
+                    'timestamp' => optional($timestamp)->diffForHumans() ?? 'just now',
+                ];
+            })
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function timeline(int $limit = 10): array
+    {
+        return $this->applications
+            ->sortByDesc(fn (Application $application) => $application->last_activity_at ?? $application->updated_at)
+            ->take($limit)
+            ->map(function (Application $application) {
+                $timestamp = $application->last_activity_at ?? $application->updated_at;
+
+                return [
+                    'id' => (string) $application->getKey(),
+                    'timestamp' => optional($timestamp)->toIso8601String(),
+                    'summary' => sprintf(
+                        '%s — %s',
+                        $application->company,
+                        $application->job_title
+                    ),
+                    'status' => $application->status->value,
+                    'company' => $application->company,
+                    'details' => $application->notes,
+                ];
+            })
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return array{total:int, byStatus: array<string,int>}
+     */
+    public function counts(): array
+    {
+        $byStatus = [];
+
+        foreach (ApplicationStatus::cases() as $status) {
+            $byStatus[$status->value] = $this->applications
+                ->filter(fn (Application $application) => $application->status === $status)
+                ->count();
+        }
+
+        return [
+            'total' => $this->applications->count(),
+            'byStatus' => $byStatus,
+        ];
+    }
+
+    protected function summaryFor(ApplicationStatus $status): string
+    {
+        return match ($status) {
+            ApplicationStatus::Applied => 'Awaiting recruiter review',
+            ApplicationStatus::OnlineAssessment => 'Assessment in progress',
+            ApplicationStatus::Interview => 'Interviews scheduled or ongoing',
+            ApplicationStatus::Passed => 'Offers or final approvals',
+            ApplicationStatus::Rejected => 'Closed and archived',
+        };
+    }
+}

--- a/backend/database/factories/ApplicationFactory.php
+++ b/backend/database/factories/ApplicationFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\ApplicationStatus;
+use App\Models\Application;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Application>
+ */
+class ApplicationFactory extends Factory
+{
+    protected $model = Application::class;
+
+    public function definition(): array
+    {
+        $status = $this->faker->randomElement(ApplicationStatus::cases());
+        $appliedAt = $this->faker->dateTimeBetween('-2 months', 'now');
+
+        return [
+            'user_id' => User::factory(),
+            'company' => $this->faker->company(),
+            'job_title' => $this->faker->jobTitle(),
+            'location' => $this->faker->city(),
+            'mode' => $this->faker->randomElement(['remote', 'hybrid', 'onsite']),
+            'source' => $this->faker->randomElement(['scraped', 'manual']),
+            'status' => $status,
+            'job_url' => $this->faker->url(),
+            'applied_at' => $appliedAt,
+            'last_activity_at' => $this->faker->dateTimeBetween($appliedAt, 'now'),
+            'notes' => $this->faker->optional()->sentence(10),
+        ];
+    }
+}

--- a/backend/database/migrations/2025_09_27_010000_create_applications_table.php
+++ b/backend/database/migrations/2025_09_27_010000_create_applications_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Enums\ApplicationStatus;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('applications', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('company');
+            $table->string('job_title');
+            $table->string('location')->nullable();
+            $table->string('mode')->nullable();
+            $table->string('source')->nullable();
+            $table->string('status')->default(ApplicationStatus::Applied->value);
+            $table->string('job_url')->nullable();
+            $table->date('applied_at')->nullable();
+            $table->timestamp('last_activity_at')->nullable();
+            $table->text('notes')->nullable();
+            $table->timestamps();
+
+            $table->index(['user_id', 'status']);
+            $table->index('last_activity_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('applications');
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\ApplicationController;
 use App\Http\Controllers\ScrapeRequestController;
 use Illuminate\Support\Facades\Route;
 
@@ -7,4 +8,11 @@ Route::prefix('scrapes')->group(function () {
     Route::get('/', [ScrapeRequestController::class, 'index'])->name('scrapes.index');
     Route::post('/', [ScrapeRequestController::class, 'store'])->name('scrapes.store');
     Route::get('{scrapeRequest}', [ScrapeRequestController::class, 'show'])->name('scrapes.show');
+});
+
+Route::middleware('auth:sanctum')->group(function () {
+    Route::get('applications', [ApplicationController::class, 'index'])->name('applications.index');
+    Route::post('applications', [ApplicationController::class, 'store'])->name('applications.store');
+    Route::match(['put', 'patch'], 'applications/{application}', [ApplicationController::class, 'update'])
+        ->name('applications.update');
 });

--- a/frontend/src/data/mock.ts
+++ b/frontend/src/data/mock.ts
@@ -1,8 +1,11 @@
 import type {
   ActivityLogItem,
+  ApplicationStatus,
   JobApplication,
   StatusMeta,
 } from '../types';
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8000';
 
 export const STATUS_META: StatusMeta[] = [
   {
@@ -37,113 +40,87 @@ export const STATUS_META: StatusMeta[] = [
   },
 ];
 
-export const MOCK_APPLICATIONS: JobApplication[] = [
-  {
-    id: 'app-245',
-    title: 'Senior Frontend Engineer',
-    company: 'Stripe',
-    location: 'Remote  AMER',
-    mode: 'remote',
-    status: 'interview',
-    source: 'scraped',
-    postedAt: '2025-09-15',
-    lastActivity: '2025-09-19T10:24:00Z',
-    notes: 'Panel interview booked for next week',
-  },
-  {
-    id: 'app-198',
-    title: 'Product Designer',
-    company: 'Linear',
-    location: 'San Francisco, CA',
-    mode: 'hybrid',
-    status: 'online_assessment',
-    source: 'manual',
-    postedAt: '2025-09-11',
-    lastActivity: '2025-09-18T18:02:00Z',
-  },
-  {
-    id: 'app-201',
-    title: 'Staff Platform Engineer',
-    company: 'Vercel',
-    location: 'Remote  Global',
-    mode: 'remote',
-    status: 'applied',
-    source: 'scraped',
-    postedAt: '2025-09-16',
-    lastActivity: '2025-09-17T08:33:00Z',
-  },
-  {
-    id: 'app-157',
-    title: 'Fullstack Engineer',
-    company: 'Canva',
-    location: 'Sydney, AU',
-    mode: 'onsite',
-    status: 'passed',
-    source: 'manual',
-    postedAt: '2025-08-10',
-    lastActivity: '2025-09-10T12:10:00Z',
-  },
-  {
-    id: 'app-129',
-    title: 'Engineering Manager',
-    company: 'Notion',
-    location: 'New York, NY',
-    mode: 'hybrid',
-    status: 'rejected',
-    source: 'scraped',
-    postedAt: '2025-07-22',
-    lastActivity: '2025-09-05T15:40:00Z',
-  },
-  {
-    id: 'app-275',
-    title: 'Data Visualization Engineer',
-    company: 'Figma',
-    location: 'Remote  AMER',
-    mode: 'remote',
-    status: 'applied',
-    source: 'scraped',
-    postedAt: '2025-09-19',
-    lastActivity: '2025-09-19T09:05:00Z',
-  },
-];
-
-export const MOCK_ACTIVITY: ActivityLogItem[] = [
-  {
-    id: 'activity-1',
-    timestamp: '2025-09-19T17:45:00Z',
-    summary: 'Sent follow-up email to Stripe recruiter',
-    status: 'interview',
-    company: 'Stripe',
-  },
-  {
-    id: 'activity-2',
-    timestamp: '2025-09-19T16:10:00Z',
-    summary: 'Completed Linear product challenge',
-    status: 'online_assessment',
-    company: 'Linear',
-  },
-  {
-    id: 'activity-3',
-    timestamp: '2025-09-18T09:25:00Z',
-    summary: 'Application submitted for Vercel role',
-    status: 'applied',
-    company: 'Vercel',
-  },
-  {
-    id: 'activity-4',
-    timestamp: '2025-09-17T20:40:00Z',
-    summary: 'Received rejection from Notion',
-    status: 'rejected',
-    company: 'Notion',
-  },
-];
-
-export const MOCK_METRICS = {
-  applicationsThisWeek: 4,
-  interviewsScheduled: 2,
-  responseRate: 38,
-  offerRate: 12,
-};
-
 export const getStatusMeta = (status: StatusMeta['key']) =>
   STATUS_META.find((item) => item.key === status)!;
+
+const normaliseStatus = (value: unknown): ApplicationStatus => {
+  const fallback: ApplicationStatus = 'applied';
+  if (typeof value !== 'string') return fallback;
+  return (
+    [
+      'applied',
+      'online_assessment',
+      'interview',
+      'passed',
+      'rejected',
+    ] as ApplicationStatus[]
+  ).includes(value as ApplicationStatus)
+    ? (value as ApplicationStatus)
+    : fallback;
+};
+
+export type ApplicationsResponse = {
+  applications: JobApplication[];
+  activity: ActivityLogItem[];
+  counts: {
+    total: number;
+    byStatus: Record<ApplicationStatus, number>;
+  };
+  pipeline: any[];
+};
+
+export const fetchApplications = async (): Promise<ApplicationsResponse> => {
+  const response = await fetch(`${API_BASE_URL}/api/applications`, {
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to load applications (${response.status})`);
+  }
+
+  const payload = await response.json();
+  const data = Array.isArray(payload?.data) ? payload.data : [];
+  const meta = payload?.meta ?? {};
+
+  const applications: JobApplication[] = data.map((item: any) => ({
+    id: String(item?.id ?? crypto.randomUUID()),
+    title: item?.title ?? item?.job_title ?? 'Untitled role',
+    company: item?.company ?? 'Unknown company',
+    location: item?.location ?? 'Remote',
+    mode: (item?.mode ?? 'remote') as JobApplication['mode'],
+    status: normaliseStatus(item?.status),
+    source: (item?.source ?? 'manual') as JobApplication['source'],
+    postedAt: item?.postedAt ?? item?.posted_at ?? new Date().toISOString(),
+    lastActivity:
+      item?.lastActivity ?? item?.last_activity ?? new Date().toISOString(),
+    notes: item?.notes ?? undefined,
+  }));
+
+  const activity: ActivityLogItem[] = Array.isArray(meta?.activity)
+    ? meta.activity.map((item: any, index: number) => ({
+        id: String(item?.id ?? `activity-${index}`),
+        timestamp: item?.timestamp ?? new Date().toISOString(),
+        summary:
+          item?.summary ?? `${item?.company ?? 'Company'} — ${item?.status ?? ''}`,
+        details: item?.details ?? undefined,
+        status: normaliseStatus(item?.status),
+        company: item?.company ?? 'Unknown company',
+      }))
+    : [];
+
+  const counts = meta?.counts ?? { total: applications.length, byStatus: {} };
+  const normalisedCounts: ApplicationsResponse['counts'] = {
+    total: typeof counts.total === 'number' ? counts.total : applications.length,
+    byStatus: {
+      applied: counts.byStatus?.applied ?? 0,
+      online_assessment: counts.byStatus?.online_assessment ?? 0,
+      interview: counts.byStatus?.interview ?? 0,
+      passed: counts.byStatus?.passed ?? 0,
+      rejected: counts.byStatus?.rejected ?? 0,
+    },
+  };
+
+  const pipeline = Array.isArray(meta?.pipeline) ? meta.pipeline : [];
+
+  return { applications, activity, counts: normalisedCounts, pipeline };
+};


### PR DESCRIPTION
## Summary
- add an Application model, enum, factory, and migration for per-user job tracking
- expose authenticated API endpoints and dashboard integration for application pipeline/activity data
- connect the Tailwind SPA dashboard to the live application API instead of mock data

## Testing
- php artisan test *(fails: vendor/autoload.php missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d7ea284300832593709ea45cab2c55