### PR TITLE
Align pipeline status keys across apps

### DIFF
--- a/backend/app/Support/ApplicationReportBuilder.php
+++ b/backend/app/Support/ApplicationReportBuilder.php
@@ -50,7 +50,8 @@ class ApplicationReportBuilder
                                 'id' => (string) $application->getKey(),
                                 'role' => $application->job_title,
                                 'company' => $application->company,
-                                'status' => $status->label(),
+                                'status' => $status->value,
+                                'status_label' => $status->label(),
                                 'applied_at' => optional($appliedAt)->diffForHumans() ?? 'just now',
                             ];
                         })

--- a/backend/resources/js/Pages/Dashboard.jsx
+++ b/backend/resources/js/Pages/Dashboard.jsx
@@ -38,16 +38,19 @@ const STAT_ICONS = {
     pipeline: WorkHistoryRoundedIcon,
 };
 
-const stagePalette = {
-    applied: 'primary',
-    interviewing: 'secondary',
-    offer: 'success',
-    rejected: 'error',
-    queued: 'info',
-    running: 'warning',
-    succeeded: 'success',
-    failed: 'error',
+const PIPELINE_STATUS_META = {
+    applied: { label: 'Applied', color: 'primary' },
+    online_assessment: { label: 'Online Assessment', color: 'info' },
+    interview: { label: 'Interview', color: 'secondary' },
+    passed: { label: 'Passed', color: 'success' },
+    rejected: { label: 'Rejected', color: 'error' },
 };
+
+const getPipelineStatusLabel = (status, fallback) =>
+    PIPELINE_STATUS_META[status]?.label ?? fallback ?? status;
+
+const getPipelineStatusColor = (status) =>
+    PIPELINE_STATUS_META[status]?.color ?? 'default';
 
 export default function Dashboard({
     stats = [],
@@ -166,14 +169,18 @@ export default function Dashboard({
                             <CardContent>
                                 <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
                                     <Box>
-                                        <Typography variant="subtitle1" fontWeight={600} textTransform="capitalize">
-                                            {stage.stage}
+                                        <Typography variant="subtitle1" fontWeight={600}>
+                                            {stage.label ?? getPipelineStatusLabel(stage.stage)}
                                         </Typography>
                                         <Typography variant="body2" color="text.secondary">
                                             {stage.summary}
                                         </Typography>
                                     </Box>
-                                    <Chip label={stage.count} color={stagePalette[stage.stage] ?? 'default'} size="small" />
+                                    <Chip
+                                        label={stage.count}
+                                        color={getPipelineStatusColor(stage.stage)}
+                                        size="small"
+                                    />
                                 </Stack>
 
                                 <Stack spacing={2}>
@@ -194,8 +201,11 @@ export default function Dashboard({
                                             <Stack direction="row" justifyContent="space-between" sx={{ mt: 1 }}>
                                                 <Chip
                                                     size="small"
-                                                    label={job.status}
-                                                    color={stagePalette[stage.stage] ?? 'primary'}
+                                                    label={
+                                                        job.status_label
+                                                            ?? getPipelineStatusLabel(job.status)
+                                                    }
+                                                    color={getPipelineStatusColor(job.status)}
                                                 />
                                                 <Typography variant="caption" color="text.secondary">
                                                     {job.applied_at}

--- a/frontend/src/data/mock.ts
+++ b/frontend/src/data/mock.ts
@@ -40,21 +40,15 @@ export const STATUS_META: StatusMeta[] = [
   },
 ];
 
+const STATUS_KEYS = STATUS_META.map((item) => item.key) as ApplicationStatus[];
+
 export const getStatusMeta = (status: StatusMeta['key']) =>
   STATUS_META.find((item) => item.key === status)!;
 
 const normaliseStatus = (value: unknown): ApplicationStatus => {
   const fallback: ApplicationStatus = 'applied';
   if (typeof value !== 'string') return fallback;
-  return (
-    [
-      'applied',
-      'online_assessment',
-      'interview',
-      'passed',
-      'rejected',
-    ] as ApplicationStatus[]
-  ).includes(value as ApplicationStatus)
+  return STATUS_KEYS.includes(value as ApplicationStatus)
     ? (value as ApplicationStatus)
     : fallback;
 };


### PR DESCRIPTION
## Summary
- emit canonical status keys from the application pipeline builder for each job entry
- map the shared status metadata in the Inertia dashboard so chips show the right labels and colors
- reuse the Tailwind SPA status enum for normalization to keep both front-ends aligned

## Testing
- php -l app/Support/ApplicationReportBuilder.php

------
https://chatgpt.com/codex/tasks/task_e_68d7eeb0d1f083259bb585bbb8816b41